### PR TITLE
Keep track of tracks for slackbot :)

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -123,6 +123,7 @@ module.exports.register = withSentry(withSentryOptions, async (event) => {
   }
 
   await Promise.all([
+    logStatistic(ddb, "track-"+ body.track_selected, 1),
     logStatistic(ddb, "registrations", 1),
     // Call DynamoDB to add the item to the table
     ddb.put(params).promise(),


### PR DESCRIPTION
Slackbot now keeps track of what each hacker selected as their track. New rows in the dynamoDB table portal-*-statistics


![image](https://user-images.githubusercontent.com/32022743/158729083-62da911f-02b3-449e-ace2-00d7ba347df2.png)
