### PR TITLE
add basic logic of email script

### DIFF
--- a/scripts/check_minor.js
+++ b/scripts/check_minor.js
@@ -4,21 +4,72 @@ AWS.config.update({ region: 'us-east-1' });
 const ses = new AWS.SES();
 const ddb = new AWS.DynamoDB.DocumentClient();
 
-const fs = require('fs');
+// const fs = require('fs');
 
-let template = fs.readFileSync('../users/email_template.html', 'utf8');
+// let template = fs.readFileSync('../users/email_template.html', 'utf8');
 // template = template.replace('{header text}',);
-let main_template = template.replace('{body text}', `<div style='display: flex; justify-content: center'><img src='https://bitcamp-assets.s3.amazonaws.com/bitcamp.png' width='722px' height='150px'></div> 
-<br/><br/>Hey Mackenzie, thanks for registering for Bitcamp 2021! 
-<br /><br />Here's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
-<br /><br />http://gotechnica.org/r?r=389bb 
-<br /><br />If you have any questions, just reply to this email. <br /><br />Best, The Bitcamp Organizing Team", /* required */`);
+let main_template = {
+  Template: {
+    TemplateName: "MainTemplate",
+    SubjectPart: "You're Registered for Bitcamp 2021! Now Refer Your Friends...",
+    TextPart: `Hey {{name}}, thanks for registering for Bitcamp 2021! 
+    \n\nHere's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
+    \n\nhttp://gotechnica.org/r?r=389bb 
+    \n\nIf you have any questions, just reply to this email.
+    \n\nBest, The Bitcamp Organizing Team`,
+    HtmlPart: `<div style='display: flex; justify-content: center'><img src='https://bitcamp-assets.s3.amazonaws.com/bitcamp.png' width='722px' height='150px'></div> 
+    <br/><br/>Hey {{name}}, thanks for registering for Bitcamp 2021! 
+    <br /><br />Here's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
+    <br /><br />http://gotechnica.org/r?r=389bb 
+    <br /><br />If you have any questions, just reply to this email. <br /><br />Best, The Bitcamp Organizing Team`
+  }
+};
 
-let minor_template = template.replace('{body text}', `<div style='display: flex; justify-content: center'><img src='https://bitcamp-assets.s3.amazonaws.com/bitcamp.png' width='722px' height='150px'></div> 
-<br/><br/>Hey Mackenzie, thanks for registering for Bitcamp 2021! 
-<br /><br />Here's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
-<br /><br />http://gotechnica.org/r?r=389bb 
-<br /><br />If you have any questions, just reply to this email. <br /><br />Best, The Bitcamp Organizing Team", /* required */`);
+let minor_template = {
+  Template: {
+    TemplateName: "MinorTemplate",
+    SubjectPart: "You're Registered for Bitcamp 2021! Now Refer Your Friends...",
+    TextPart: `Hey {{name}}, thanks for registering for Bitcamp 2021! 
+    \n\nHere's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
+    \n\nhttp://gotechnica.org/r?r=389bb 
+    \n\nIf you have any questions, just reply to this email.
+    \n\nBest, The Bitcamp Organizing Team`,
+    HtmlPart: `<div style='display: flex; justify-content: center'><img src='https://bitcamp-assets.s3.amazonaws.com/bitcamp.png' width='722px' height='150px'></div> 
+    <br/><br/>Hey {{name}}, thanks for registering for Bitcamp 2021! 
+    <br /><br />Here's your custom referral link - you can win prizes and swag by having your friends use it to register for Bitcamp as well! 
+    <br /><br />http://gotechnica.org/r?r=389bb 
+    <br /><br />If you have any questions, just reply to this email. <br /><br />Best, The Bitcamp Organizing Team`
+  }
+};
+
+(async function () {
+  var templatePromise1 = await ses.createTemplate(main_template).promise();
+
+  // Handle promise's fulfilled/rejected states
+  templatePromise1.then(
+    function (data) {
+      console.log(data);
+    }
+  ).catch(
+    function (err) {
+      console.error(err, err.stack);
+    }
+  );
+
+  var templatePromise2 = await ses.createTemplate(minor_template).promise();
+
+  // Handle promise's fulfilled/rejected states
+  templatePromise2.then(
+    function (data) {
+      console.log(data);
+    }
+  ).catch(
+    function (err) {
+      console.error(err, err.stack);
+    }
+  );
+})();
+
 
 // if you're 18 by the first day of bitcamp that means you were born <= Apr 8 2004
 // monthIndex for April is 3
@@ -28,33 +79,60 @@ const scan_params = {
   TableName: 'portal-prd-registration',
 };
 
+let main_emails = [];
+let minor_emails = [];
+
 (async function () {
   const result = await ddb.scan(scan_params).promise();
 
   result.Items.forEach(element => {
-    const params = {
-      Destination: { /* required */
-        ToAddresses: [
-          element.email,
-        ],
-      },
-      Message: { /* required */
-        Body: { /* required */
-          Html: {
-            Data: (new Date(element.birthday) < cutoff ? main_template : minor_template),
-          },
+    if (new Date(element.birthday) < cutoff) {
+      main_emails.push({
+        "Destination": {
+          "ToAddresses": [
+            element.email,
+          ]
         },
-        Subject: { /* required */
-          Data: "You're Registered for Bitcamp 2021! Now Refer Your Friends...", /* required */
+        "ReplacementTemplateData": "{ \"name\":\"" + element.name + "\"}"
+      });
+    } else {
+      minor_emails.push({
+        "Destination": {
+          "ToAddresses": [
+            element.email,
+          ]
         },
-      },
-      ConfigurationSetName: 'platform_prod',
-      Source: 'hello@bit.camp', /* required */
-    };
-    ses.sendEmail(params, (err, data) => {
-      if (err) console.log(err, err.stack); // an error occurred
-      else console.log(data); // successful response
-    });
+        "ReplacementTemplateData": "{ \"name\":\"" + element.name + "\"}"
+      });
+    }
+  });
+
+  const main_params = {
+    Destinations: [
+      main_emails,
+    ],
+    ConfigurationSetName: 'platform_prod',
+    Source: 'hello@bit.camp', /* required */
+    Template: "MainTemplate",
+    DefaultTemplateData: '{ \"name\":\"Participant\" }',
+  };
+  ses.sendBulkTemplatedEmail(main_params, (err, data) => {
+    if (err) console.log(err, err.stack); // an error occurred
+    else console.log(data); // successful response
+  });
+
+  const minor_params = {
+    Destinations: [
+      minor_emails,
+    ],
+    ConfigurationSetName: 'platform_prod',
+    Source: 'hello@bit.camp', /* required */
+    Template: "MinorTemplate",
+    DefaultTemplateData: '{ \"name\":\"BitCamp Participant\" }',
+  };
+  ses.sendBulkTemplatedEmail(minor_params, (err, data) => {
+    if (err) console.log(err, err.stack); // an error occurred
+    else console.log(data); // successful response
   });
 
 })();


### PR DESCRIPTION
Added `check_minor.js`, which is a script that sends a different email to minors vs non minors. It creates two different email templates (note that if you're using this script more than once, that part only needs to happen once), and then sends everyone who's registered the correct email depending on if they're 18 when bitcamp starts or not. 

Note: I didn't actually test any of the SES functionality since I don't have real templates. 