### PR TITLE
Add quantum track specific survey quesitons

### DIFF
--- a/frontend/src/components/RegistrationForm.vue
+++ b/frontend/src/components/RegistrationForm.vue
@@ -403,7 +403,7 @@
         <!-- Optional quantum selection 1 -->
         <hr />
         <b-form-group v-if="this.form.QUANTUM_SELECTED" class="font-weight-bold"
-          label="Would you like to be placed in the beginner or advanced quantum track.*">
+          label="Would you like to be placed in the beginner or advanced quantum track?*">
           <b-form-radio-group id="quantum-survey-1" v-model="form.selected_quantum_survey_track"
             class="font-weight-normal pt-2" :state="quantum_survey_1">
             <b-form-radio value="r"> Beginner </b-form-radio>
@@ -412,11 +412,12 @@
           <b-form-invalid-feedback :state="quantum_survey_1">
             Please select an answer
           </b-form-invalid-feedback>
+          <hr />
         </b-form-group>
 
         <!-- Optional quantum selection 2 -->
-        <hr />
-        <b-form-group v-if="this.form.QUANTUM_SELECTED" class="font-weight-bold"
+
+        <b-form-group class="font-weight-bold"
           label="Although we are not offering a beginner track this year, Bitcamp remains committed to being a hackathon for hackers of all skill levels and experiences, and we’re working to ensure that our workshops are beginner-friendly. Additionally, we will be creating and offering access to hacker guides, tips on how to make the most of your Bitcamp weekend, and different resources that you can leverage when creating your hack! Would you like us to share this content with you?*">
           <b-form-radio-group id="quantum-survey-2" v-model="form.selected_quantum_survey_guide"
             class="font-weight-normal pt-2" :state="quantum_survey_2">
@@ -1610,7 +1611,7 @@ export default {
         this.quantum_survey_1 = null;
       }
 
-      if (!this.form.selected_quantum_survey_guide && this.form.QUANTUM_SELECTED) {
+      if (!this.form.selected_quantum_survey_guide) {
         this.quantum_survey_2 = false;
         valid_form = false;
       } else {


### PR DESCRIPTION
- Added the track specific question when a user chooses the quantum track.
- Added the resources survey question that always shows when registering
- Added two new survey questions, one for choosing to beginner or advanced and another for the question pasted in the ticket: "Although we are not offering a beginner track this year...Would you like us to share this content with you?"
- Validated the form, (if the user chooses quantum and doesnt fill any of the two questions an error will be shown and the form will not submit)
<img width="565" alt="image" src="https://github.com/bitcamp/portal/assets/86363939/49b1862d-d5b5-4c95-b1c0-7d816ec9ce11">
<img width="576" alt="image" src="https://github.com/bitcamp/portal/assets/86363939/dc77deb4-5375-4672-b79c-4e87f2fa6549">
<img width="592" alt="image" src="https://github.com/bitcamp/portal/assets/86363939/3f847ace-298c-4042-8ff8-19a51be508f8">
<img width="531" alt="image" src="https://github.com/bitcamp/portal/assets/86363939/287fbdbb-abc0-45ec-a2fc-36dbf026e057">